### PR TITLE
Fix clang-format ContinuationIndentWidth

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ BraceWrapping:
 BreakBeforeBraces: Custom
 ColumnLimit: 100
 ConstructorInitializerIndentWidth: 0
-ContinuationIndentWidth: 2
+ContinuationIndentWidth: 4
 DerivePointerAlignment: false
 PointerAlignment: Middle
 ReflowComments: false


### PR DESCRIPTION
* ContinuationIndentWidthを4に変更