### PR TITLE
Porting/pubsub of ros2 emcl2 node

### DIFF
--- a/include/emcl2/emcl2_node.h
+++ b/include/emcl2/emcl2_node.h
@@ -14,9 +14,11 @@
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
 */
-// #include "geometry_msgs/PoseWithCovarianceStamped.h"
-// #include "sensor_msgs/LaserScan.h"
-// #include "std_srvs/Empty.h"
+#include "geometry_msgs/msg/pose_array.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "std_msgs/msg/float32.hpp"
+//#include "std_srvs/srv/empty.h"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/LinearMath/Transform.h"
 
@@ -34,20 +36,22 @@ class EMcl2Node : public rclcpp::Node
 
       private:
 	// std::shared_ptr<ExpResetMcl2> pf_;
-	/* came from amcl. 
-	ros::NodeHandle nh_;
-	ros::NodeHandle private_nh_;
 
-	ros::Publisher particlecloud_pub_; 
-	ros::Publisher pose_pub_;
-	*/
-	// ros::Publisher alpha_pub_;
-	/* came from amcl. 
-	ros::Subscriber laser_scan_sub_;
-	ros::Subscriber initial_pose_sub_;
+	//ros::NodeHandle nh_;
+	//ros::NodeHandle private_nh_;
 
-	ros::ServiceServer global_loc_srv_;
-	*/
+	rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr particlecloud_pub_;
+
+	rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_pub_;
+
+	rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr alpha_pub_;
+
+	rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
+
+	rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
+	  initial_pose_sub_;
+
+	//ros::ServiceServer global_loc_srv_;
 
 	// ros::Time scan_time_stamp_;
 
@@ -86,10 +90,10 @@ class EMcl2Node : public rclcpp::Node
 	// std::shared_ptr<LikelihoodFieldMap> initMap(void);
 	// std::shared_ptr<OdomModel> initOdometry(void);
 
-	// void cbScan(const sensor_msgs::LaserScan::ConstPtr & msg);
+	void cbScan(const sensor_msgs::msg::LaserScan::SharedPtr msg);
 	// bool cbSimpleReset(std_srvs::Empty::Request & req, std_srvs::Empty::Response & res);
-	// void initialPoseReceived(
-	//     const geometry_msgs::PoseWithCovarianceStampedConstPtr & msg);  //same name is found in amcl
+	void initialPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr
+				   msg);  //same name is found in amcl
 };
 
 }  // namespace emcl2

--- a/include/emcl2/emcl2_node.h
+++ b/include/emcl2/emcl2_node.h
@@ -41,13 +41,9 @@ class EMcl2Node : public rclcpp::Node
 	//ros::NodeHandle private_nh_;
 
 	rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr particlecloud_pub_;
-
 	rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_pub_;
-
 	rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr alpha_pub_;
-
 	rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
-
 	rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
 	  initial_pose_sub_;
 
@@ -90,9 +86,9 @@ class EMcl2Node : public rclcpp::Node
 	// std::shared_ptr<LikelihoodFieldMap> initMap(void);
 	// std::shared_ptr<OdomModel> initOdometry(void);
 
-	void cbScan(const sensor_msgs::msg::LaserScan::SharedPtr msg);
+	void cbScan(sensor_msgs::msg::LaserScan::ConstSharedPtr msg);
 	// bool cbSimpleReset(std_srvs::Empty::Request & req, std_srvs::Empty::Response & res);
-	void initialPoseReceived(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr
+	void initialPoseReceived(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr
 				   msg);  //same name is found in amcl
 };
 

--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -5,9 +5,7 @@
 #include "emcl2/emcl2_node.h"
 
 // #include "emcl/Pose.h"
-// #include "geometry_msgs/PoseArray.h"
 // #include "nav_msgs/GetMap.h"
-// #include "std_msgs/Float32.h"
 #include "tf2/utils.h"
 
 namespace emcl2
@@ -28,11 +26,15 @@ EMcl2Node::~EMcl2Node() {}
 
 void EMcl2Node::initCommunication(void)
 {
-	// particlecloud_pub_ = nh_.advertise<geometry_msgs::PoseArray>("particlecloud", 2, true);
-	// pose_pub_ = nh_.advertise<geometry_msgs::PoseWithCovarianceStamped>("mcl_pose", 2, true);
-	// alpha_pub_ = nh_.advertise<std_msgs::Float32>("alpha", 2, true);
-	// laser_scan_sub_ = nh_.subscribe("scan", 2, &EMcl2Node::cbScan, this);
-	// initial_pose_sub_ = nh_.subscribe("initialpose", 2, &EMcl2Node::initialPoseReceived, this);
+	particlecloud_pub_ = create_publisher<geometry_msgs::msg::PoseArray>("particlecloud", 2);
+	pose_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("mcl_pose", 2);
+	alpha_pub_ = create_publisher<std_msgs::msg::Float32>("alpha", 2);
+
+	auto callback = std::bind(&EMcl2Node::cbScan, this, std::placeholders::_1);
+	laser_scan_sub_ = create_subscription<sensor_msgs::msg::LaserScan>("scan", 2, callback);
+	initial_pose_sub_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+	  "initialpose", 2,
+	  std::bind(&EMcl2Node::initialPoseReceived, this, std::placeholders::_1));
 
 	// global_loc_srv_ = nh_.advertiseService("global_localization", &EMcl2Node::cbSimpleReset, this);
 
@@ -110,20 +112,21 @@ void EMcl2Node::initPF(void)
 //   return std::shared_ptr<LikelihoodFieldMap>(new LikelihoodFieldMap(resp.map, likelihood_range));
 // }
 
-// void EMcl2Node::cbScan(const sensor_msgs::LaserScan::ConstPtr & msg)
-// {
-//   scan_time_stamp_ = msg->header.stamp;
-//   scan_frame_id_ = msg->header.frame_id;
-//   pf_->setScan(msg);
-// }
+void EMcl2Node::cbScan(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+{
+	//   scan_time_stamp_ = msg->header.stamp;
+	//   scan_frame_id_ = msg->header.frame_id;
+	//   pf_->setScan(msg);
+}
 
-// void EMcl2Node::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedConstPtr & msg)
-// {
-//   init_request_ = true;
-//   init_x_ = msg->pose.pose.position.x;
-//   init_y_ = msg->pose.pose.position.y;
-//   init_t_ = tf2::getYaw(msg->pose.pose.orientation);
-// }
+void EMcl2Node::initialPoseReceived(
+  const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
+{
+	//init_request_ = true;
+	//init_x_ = msg->pose.pose.position.x;
+	//init_y_ = msg->pose.pose.position.y;
+	//init_t_ = tf2::getYaw(msg->pose.pose.orientation);
+}
 
 void EMcl2Node::loop(void)
 {
@@ -170,16 +173,16 @@ void EMcl2Node::loop(void)
 	publishPose(x, y, t, x_var, y_var, t_var, xy_cov, yt_cov, tx_cov);
 	publishParticles();
 
-	// std_msgs::Float32 alpha_msg;
+	std_msgs::msg::Float32 alpha_msg;
 	// alpha_msg.data = static_cast<float>(pf_->alpha_);
-	// alpha_pub_.publish(alpha_msg);
+	alpha_pub_->publish(alpha_msg);
 }
 
 void EMcl2Node::publishPose(
   double x, double y, double t, double x_dev, double y_dev, double t_dev, double xy_cov,
   double yt_cov, double tx_cov)
 {
-	// geometry_msgs::PoseWithCovarianceStamped p;
+	geometry_msgs::msg::PoseWithCovarianceStamped p;
 	// p.header.frame_id = global_frame_id_;
 	// p.header.stamp = ros::Time::now();
 	// p.pose.pose.position.x = x;
@@ -200,7 +203,7 @@ void EMcl2Node::publishPose(
 	q.setRPY(0, 0, t);
 	// tf2::convert(q, p.pose.pose.orientation);
 
-	// pose_pub_.publish(p);
+	pose_pub_->publish(p);
 }
 
 void EMcl2Node::publishOdomFrame(double x, double y, double t)
@@ -236,7 +239,7 @@ void EMcl2Node::publishOdomFrame(double x, double y, double t)
 
 void EMcl2Node::publishParticles(void)
 {
-	// geometry_msgs::PoseArray cloud_msg;
+	geometry_msgs::msg::PoseArray cloud_msg;
 	// cloud_msg.header.stamp = ros::Time::now();
 	// cloud_msg.header.frame_id = global_frame_id_;
 	// cloud_msg.poses.resize(pf_->particles_.size());
@@ -250,7 +253,7 @@ void EMcl2Node::publishParticles(void)
 	//   q.setRPY(0, 0, pf_->particles_[i].p_.t_);
 	//   tf2::convert(q, cloud_msg.poses[i].orientation);
 	// }
-	// particlecloud_pub_.publish(cloud_msg);
+	particlecloud_pub_->publish(cloud_msg);
 }
 
 /* came from amcl. This function must be rewritten 

--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -30,8 +30,8 @@ void EMcl2Node::initCommunication(void)
 	pose_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("mcl_pose", 2);
 	alpha_pub_ = create_publisher<std_msgs::msg::Float32>("alpha", 2);
 
-	auto callback = std::bind(&EMcl2Node::cbScan, this, std::placeholders::_1);
-	laser_scan_sub_ = create_subscription<sensor_msgs::msg::LaserScan>("scan", 2, callback);
+	laser_scan_sub_ = create_subscription<sensor_msgs::msg::LaserScan>(
+	  "scan", 2, std::bind(&EMcl2Node::cbScan, this, std::placeholders::_1));
 	initial_pose_sub_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
 	  "initialpose", 2,
 	  std::bind(&EMcl2Node::initialPoseReceived, this, std::placeholders::_1));
@@ -112,7 +112,7 @@ void EMcl2Node::initPF(void)
 //   return std::shared_ptr<LikelihoodFieldMap>(new LikelihoodFieldMap(resp.map, likelihood_range));
 // }
 
-void EMcl2Node::cbScan(const sensor_msgs::msg::LaserScan::SharedPtr msg)
+void EMcl2Node::cbScan(sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
 {
 	//   scan_time_stamp_ = msg->header.stamp;
 	//   scan_frame_id_ = msg->header.frame_id;
@@ -120,7 +120,7 @@ void EMcl2Node::cbScan(const sensor_msgs::msg::LaserScan::SharedPtr msg)
 }
 
 void EMcl2Node::initialPoseReceived(
-  const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
+  geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
 {
 	//init_request_ = true;
 	//init_x_ = msg->pose.pose.position.x;


### PR DESCRIPTION
パブリッシャとサブスクライバの箇所をROS 2に移行し、修正が完了した後名前を変更したので新しくプルリク出します。
