### PR TITLE
Porting service code for ROS 2

### DIFF
--- a/include/emcl2/emcl2_node.h
+++ b/include/emcl2/emcl2_node.h
@@ -18,10 +18,10 @@
 */
 #include "geometry_msgs/msg/pose_array.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "std_msgs/msg/float32.hpp"
-//#include "std_srvs/srv/empty.h"
-#include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/empty.hpp"
 #include "tf2/LinearMath/Transform.h"
 
 namespace emcl2
@@ -48,9 +48,10 @@ class EMcl2Node : public rclcpp::Node
 	rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
 	rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
 	  initial_pose_sub_;
+	rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;
 
 	//ros::ServiceServer global_loc_srv_;
-
+	rclcpp::Service<std_srvs::srv::Empty>::SharedPtr global_loc_srv_;
 	// ros::Time scan_time_stamp_;
 
 	std::string footprint_frame_id_;
@@ -70,6 +71,7 @@ class EMcl2Node : public rclcpp::Node
 	int odom_freq_;
 	bool init_request_;
 	bool simple_reset_request_;
+	bool map_receive_;
 	double init_x_, init_y_, init_t_;
 
 	void publishPose(
@@ -80,14 +82,20 @@ class EMcl2Node : public rclcpp::Node
 	void sendTf(void);
 	bool getOdomPose(double & x, double & y, double & yaw);	 //same name is found in amcl
 	bool getLidarPose(double & x, double & y, double & yaw, bool & inv);
+	void receiveMap(nav_msgs::msg::OccupancyGrid::SharedPtr msg);
 
 	void initCommunication(void);
 	void initPF(void);
 	std::shared_ptr<LikelihoodFieldMap> initMap(void);
 	std::shared_ptr<OdomModel> initOdometry(void);
 
+	nav_msgs::msg::OccupancyGrid map_;
+
 	void cbScan(sensor_msgs::msg::LaserScan::ConstSharedPtr msg);
 	// bool cbSimpleReset(std_srvs::Empty::Request & req, std_srvs::Empty::Response & res);
+	bool cbSimpleReset(
+	  std::shared_ptr<std_srvs::srv::Empty::Request> req,
+	  std::shared_ptr<std_srvs::srv::Empty::Response> res);
 	void initialPoseReceived(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr
 				   msg);  //same name is found in amcl
 };

--- a/include/emcl2/emcl2_node.h
+++ b/include/emcl2/emcl2_node.h
@@ -48,7 +48,7 @@ class EMcl2Node : public rclcpp::Node
 	rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr laser_scan_sub_;
 	rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
 	  initial_pose_sub_;
-	rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::ConstSharedPtr map_sub_;
+	rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
 
 	//ros::ServiceServer global_loc_srv_;
 	rclcpp::Service<std_srvs::srv::Empty>::SharedPtr global_loc_srv_;

--- a/include/emcl2/emcl2_node.h
+++ b/include/emcl2/emcl2_node.h
@@ -82,7 +82,7 @@ class EMcl2Node : public rclcpp::Node
 	void sendTf(void);
 	bool getOdomPose(double & x, double & y, double & yaw);	 //same name is found in amcl
 	bool getLidarPose(double & x, double & y, double & yaw, bool & inv);
-	void receiveMap(nav_msgs::msg::OccupancyGrid::SharedPtr msg);
+	void receiveMap(nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);
 
 	void initCommunication(void);
 	void initPF(void);
@@ -94,8 +94,8 @@ class EMcl2Node : public rclcpp::Node
 	void cbScan(sensor_msgs::msg::LaserScan::ConstSharedPtr msg);
 	// bool cbSimpleReset(std_srvs::Empty::Request & req, std_srvs::Empty::Response & res);
 	bool cbSimpleReset(
-	  std::shared_ptr<std_srvs::srv::Empty::Request> req,
-	  std::shared_ptr<std_srvs::srv::Empty::Response> res);
+	  std_srvs::srv::Empty::Request::SharedPtr req,
+	  std_srvs::srv::Empty::Response::SharedPtr res);
 	void initialPoseReceived(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr
 				   msg);  //same name is found in amcl
 };

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>std_srvs</depend>
   
   <depend>backward_ros</depend>
 

--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -131,16 +131,13 @@ std::shared_ptr<LikelihoodFieldMap> EMcl2Node::initMap(void)
 	this->declare_parameter("num_particles", 0);
 	this->get_parameter("num_particles", num);
 
-	nav_msgs::srv::GetMap::Request req;
-	nav_msgs::srv::GetMap::Response resp;
 	//   ROS_INFO("Requesting the map...");
 	//   while (!ros::service::call("static_map", req, resp)) {
 	//     ROS_WARN("Request for map failed; trying again...");
 	//     ros::Duration d(0.5);
 	//     d.sleep();
 	//   }
-	return std::shared_ptr<LikelihoodFieldMap>(
-	  new LikelihoodFieldMap(resp.map, likelihood_range));
+	return std::shared_ptr<LikelihoodFieldMap>(new LikelihoodFieldMap(map_, likelihood_range));
 }
 
 void EMcl2Node::receiveMap(nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg)

--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -8,7 +8,6 @@
 #include "emcl2/OdomModel.h"
 #include "emcl2/Pose.h"
 #include "emcl2/Scan.h"
-#include "nav_msgs/srv/get_map.hpp"
 #include "tf2/utils.h"
 
 namespace emcl2

--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -39,8 +39,13 @@ void EMcl2Node::initCommunication(void)
 	initial_pose_sub_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
 	  "initialpose", 2,
 	  std::bind(&EMcl2Node::initialPoseReceived, this, std::placeholders::_1));
+	map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
+	  "map", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
+	  std::bind(&EMcl2Node::receiveMap, this, std::placeholders::_1));
 
-	// global_loc_srv_ = nh_.advertiseService("global_localization", &EMcl2Node::cbSimpleReset, this);
+	global_loc_srv_ = create_service<std_srvs::srv::Empty>(
+	  "global_localization",
+	  std::bind(&EMcl2Node::cbSimpleReset, this, std::placeholders::_1, std::placeholders::_2));
 
 	this->declare_parameter("global_frame_id", std::string("map"));
 	this->declare_parameter("footprint_frame_id", std::string("base_footprint"));
@@ -136,6 +141,13 @@ std::shared_ptr<LikelihoodFieldMap> EMcl2Node::initMap(void)
 	//   }
 	return std::shared_ptr<LikelihoodFieldMap>(
 	  new LikelihoodFieldMap(resp.map, likelihood_range));
+}
+
+void EMcl2Node::receiveMap(nav_msgs::msg::OccupancyGrid::SharedPtr msg)
+{
+	map_ = *msg;
+	map_receive_ = true;
+	RCLCPP_INFO(get_logger(), "Received map.");
 }
 
 void EMcl2Node::cbScan(sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
@@ -332,10 +344,12 @@ bool EMcl2Node::getLidarPose(double & x, double & y, double & yaw, bool & inv)
 
 int EMcl2Node::getOdomFreq(void) { return odom_freq_; }
 
-// bool EMcl2Node::cbSimpleReset(std_srvs::Empty::Request & req, std_srvs::Empty::Response & res)
-// {
-//   return simple_reset_request_ = true;
-// }
+bool EMcl2Node::cbSimpleReset(
+  std::shared_ptr<std_srvs::srv::Empty::Request> req,
+  std::shared_ptr<std_srvs::srv::Empty::Response> res)
+{
+	return simple_reset_request_ = true;
+}
 
 }  // namespace emcl2
 

--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<LikelihoodFieldMap> EMcl2Node::initMap(void)
 	  new LikelihoodFieldMap(resp.map, likelihood_range));
 }
 
-void EMcl2Node::receiveMap(nav_msgs::msg::OccupancyGrid::SharedPtr msg)
+void EMcl2Node::receiveMap(nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg)
 {
 	map_ = *msg;
 	map_receive_ = true;
@@ -345,8 +345,7 @@ bool EMcl2Node::getLidarPose(double & x, double & y, double & yaw, bool & inv)
 int EMcl2Node::getOdomFreq(void) { return odom_freq_; }
 
 bool EMcl2Node::cbSimpleReset(
-  std::shared_ptr<std_srvs::srv::Empty::Request> req,
-  std::shared_ptr<std_srvs::srv::Empty::Response> res)
+  std_srvs::srv::Empty::Request::SharedPtr req, std_srvs::srv::Empty::Response::SharedPtr res)
 {
 	return simple_reset_request_ = true;
 }


### PR DESCRIPTION
以下のファイルのサービス箇所をROS 2に移行し、[`ros::service::call`](https://github.com/CIT-Autonomous-Robot-Lab/emcl2_ros2/blob/c95d729f52fd5fd3a0e9ac772862e643e8f06faa/src/emcl2_node.cpp#L137)の箇所をサブスクライバとして実装しました。また`package.xml`に`<depend>std_srvs</depend>`を付け足しました。

- emcl2_node,h
- emcl2_node.cpp
