### PR TITLE
Change config not to use sensor_reset

### DIFF
--- a/config/emcl2_quick_start.param.yaml
+++ b/config/emcl2_quick_start.param.yaml
@@ -17,7 +17,7 @@
     expansion_radius_orientation: 0.2
     extraction_rate: 0.1
     range_threshold: 0.3
-    sensor_reset: true
+    sensor_reset: false
     odom_fw_dev_per_fw: 0.19
     odom_fw_dev_per_rot: 0.0001
     odom_rot_dev_per_fw: 0.13


### PR DESCRIPTION
One of the config files has never been changed to turn sensor reset off. 