### PR TITLE
move declare_parameter() into constructor

### DIFF
--- a/include/emcl2/emcl2_node.h
+++ b/include/emcl2/emcl2_node.h
@@ -28,7 +28,6 @@
 
 namespace emcl2
 {
-
 class EMcl2Node : public rclcpp::Node
 {
       public:
@@ -85,6 +84,8 @@ class EMcl2Node : public rclcpp::Node
 	bool getOdomPose(double & x, double & y, double & yaw);	 // same name is found in amcl
 	bool getLidarPose(double & x, double & y, double & yaw, bool & inv);
 	void receiveMap(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);
+
+	void declareParameter();
 
 	void initCommunication(void);
 	void initTF();


### PR DESCRIPTION
## Description
When map is callback twice, declare_parameter is also called twice and the process dies, so move the part that calls declare_parameter into constructor.