### PR TITLE
added a parameter init

### DIFF
--- a/src/emcl2_node.cpp
+++ b/src/emcl2_node.cpp
@@ -32,6 +32,7 @@ namespace emcl2
 EMcl2Node::EMcl2Node()
 : Node("emcl2_node"),
   ros_clock_(RCL_SYSTEM_TIME),
+  init_pf_(false),
   init_request_(false),
   simple_reset_request_(false),
   scan_receive_(false),


### PR DESCRIPTION
I found that you forgot to initialize the `init_pf_` variable in the `EMcl2Node` class.
I added the initialization process, so please check it !