### PR TITLE
Fixed to use laser_min_range and laser_max_range

### DIFF
--- a/src/Mcl.cpp
+++ b/src/Mcl.cpp
@@ -229,8 +229,6 @@ void Mcl::setScan(const sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
 	scan_.angle_min_ = msg->angle_min;
 	scan_.angle_max_ = msg->angle_max;
 	scan_.angle_increment_ = msg->angle_increment;
-	scan_.range_min_ = msg->range_min;
-	scan_.range_max_ = msg->range_max;
 }
 
 double Mcl::normalizeBelief(void)


### PR DESCRIPTION
I fixed the following problem.

## Problem

`emcl2_ros2` provides the following parameters.

- laser_min_range
- laser_max_range

But, these value has been overwritten by the input scan value in `Mcl::setScan()`.

```cpp
void Mcl::setScan(const sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
{
	if (msg->ranges.size() != scan_.ranges_.size()) {
		scan_.ranges_.resize(msg->ranges.size());
	}

	scan_.seq_ = msg->header.stamp.sec;
	for (size_t i = 0; i < msg->ranges.size(); i++) {
		scan_.ranges_[i] = msg->ranges[i];
	}

	scan_.angle_min_ = msg->angle_min;
	scan_.angle_max_ = msg->angle_max;
	scan_.angle_increment_ = msg->angle_increment;
	scan_.range_min_ = msg->range_min; // overwritten by the input scan value
	scan_.range_max_ = msg->range_max; // overwritten by the input scan value
}
```